### PR TITLE
Force Python2 with /usr/bin/env python2.7 hasbang

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # -*- coding: utf-8 -*-
 from __future__ import division, unicode_literals
 


### PR DESCRIPTION
This change adds `#!/usr/bin/env python2.7` hashbang to the
`__init__.py` script — to force the use of Python2.7 when the script is
run as an executable. Otherwise without this change, in environments
where Python3 is the default, the shell would try to run the script with
Python3 (and that’ll fail, since it’s not Python3-compatible...).