### PR TITLE
Ensure (html, css) output gets encoded in UTF-8

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -35,13 +35,13 @@ def cli():
 	html,css = highlight(input, **options)
 	if options['just'] == "html":
 	    if options['output'] == "html":
-	        print html
+	        print html.encode('utf-8')
 	    else:
-	        print json.dumps(html)
+	        print json.dumps(html.encode('utf-8'))
 	elif options['just'] == "css":
-	    print css
+	    print css.encode('utf-8')
 	else:
-	    print json.dumps({"html":html, "css":css})
+	    print json.dumps({"html":html.encode('utf-8'), "css":css.encode('utf-8')})
 
 if __name__ == '__main__':
 	cli()


### PR DESCRIPTION
Without this change, when running the examples from the HTML spec through
the highlighter, processing back through wattsi fails for all examples that
contain non-ASCII characters.