### PR TITLE
Make highlight server not log requests

### DIFF
--- a/server.py
+++ b/server.py
@@ -27,6 +27,8 @@ class myHandler(BaseHTTPRequestHandler):
 		self.send_header('Content-type',"text/plain")
 		self.end_headers()
 		self.wfile.write(html.encode("utf-8"))
+	def log_request(self, *args):
+		return
 
 def do_404(handler):
 	handler.send_response(404)


### PR DESCRIPTION
This change makes the highlight server not log requests. The output is
otherwise extremely verbose.