### PR TITLE
Raise special exception for Web IDL syntax errors

### DIFF
--- a/highlighter/highlight.py
+++ b/highlighter/highlight.py
@@ -20,7 +20,7 @@ def die(msg, *rargs, **kwargs):
     raise Exception(msg.format(*rargs, **kwargs))
 
 def warn(msg, *rargs, **kwargs):
-    print msg.format(*rargs, **kwargs)
+    raise SyntaxWarning(msg.format(*rargs, **kwargs))
 
 def highlight(html, lang, lineNumbers=False, lineStart=1, lineHighlights=set(), output="json", unescape=False, **unusedKwargs):
     if unescape:
@@ -94,7 +94,6 @@ def highlightWithWebIDL(text):
     class IDLUI(object):
         def warn(self, msg):
             warn("{0}", msg.rstrip())
-            raise SyntaxWarning("Invalid Web IDL found.")
     class HighlightMarker(object):
         # Just applies highlighting classes to IDL stuff.
         def markupTypeName(self, text, construct):

--- a/highlighter/highlight.py
+++ b/highlighter/highlight.py
@@ -94,6 +94,7 @@ def highlightWithWebIDL(text):
     class IDLUI(object):
         def warn(self, msg):
             warn("{0}", msg.rstrip())
+            raise SyntaxWarning("Invalid Web IDL found.")
     class HighlightMarker(object):
         # Just applies highlighting classes to IDL stuff.
         def markupTypeName(self, text, construct):

--- a/server.py
+++ b/server.py
@@ -25,8 +25,8 @@ class myHandler(BaseHTTPRequestHandler):
 
 		try:
 			html,css = highlight(data, lang=lang, output="html", unescape=True)
-		except:
-			do_400(self)
+		except Exception as err:
+			do_400(self, err)
 			return
 		self.send_response(200)
 		self.send_header('Content-type',"text/plain")
@@ -41,11 +41,14 @@ def do_404(handler):
 	handler.end_headers()
 	handler.wfile.write("Invalid request, must send JSON as the path.")
 
-def do_400(handler):
+def do_400(handler, err):
 	handler.send_response(400)
 	handler.send_header('Content-type','text/plain')
 	handler.end_headers()
-	handler.wfile.write("Unexpected error:\n{0}".format(sys.exc_info()[0]))
+	if isinstance(err, SyntaxWarning):
+		handler.wfile.write(str(err))
+	else:
+		handler.wfile.write("Unexpected error:\n{0}".format(sys.exc_info()[0]))
 
 try:
 	#Create a web server and define the handler to manage the


### PR DESCRIPTION
This change:

* causes a special exception to be raised for any Web IDL syntax errors
* causes the existing 400-response handler in server.py to use that special exception's message for the response body of the 400 response
* otherwise, for any exceptions other than our special exception, causes the response body to be a generic "Unexpected error" message

Fixes https://github.com/tabatkins/highlighter/issues/14