### PR TITLE
Tweak color contrast (fixes #25)

### DIFF
--- a/highlighter/styles.py
+++ b/highlighter/styles.py
@@ -4,18 +4,18 @@
 #class PrismStyle(style.Style):
 #    default_style = "#000000"
 #    styles = {
-#        token.Name: "#0077aa",
-#        token.Name.Tag: "#669900",
+#        token.Name: "#007299",
+#        token.Name.Tag: "#008000",
 #        token.Name.Builtin: "noinherit",
 #        token.Name.Variable: "#222222",
 #        token.Name.Other: "noinherit",
-#        token.Operator: "#999999",
-#        token.Punctuation: "#999999",
-#        token.Keyword: "#990055",
+#        token.Operator: "#008000",
+#        token.Punctuation: "#545454",
+#        token.Keyword: "#d91e18",
 #        token.Literal: "#000000",
 #        token.Literal.Number: "#000000",
-#        token.Literal.String: "#a67f59",
-#        token.Comment: "#708090"
+#        token.Literal.String: "#aa5d00",
+#        token.Comment: "#696969"
 #    }
 #print formatters.HtmlFormatter(style=PrismStyle).get_style_defs('.highlight')
 
@@ -36,57 +36,57 @@ highlight = '''
 .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
 code.highlight { padding: .1em; border-radius: .3em; }
 pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-c-[a] { color: #990055 } /* Keyword.Declaration */
-c-[b] { color: #990055 } /* Keyword.Type */
-c-[c] { color: #708090 } /* Comment */
-c-[d] { color: #708090 } /* Comment.Multiline */
-c-[e] { color: #0077aa } /* Name.Attribute */
-c-[f] { color: #669900 } /* Name.Tag */
+c-[a] { color: #d91e18 } /* Keyword.Declaration */
+c-[b] { color: #d91e18 } /* Keyword.Type */
+c-[c] { color: #696969 } /* Comment */
+c-[d] { color: #696969 } /* Comment.Multiline */
+c-[e] { color: #007299 } /* Name.Attribute */
+c-[f] { color: #008000 } /* Name.Tag */
 c-[g] { color: #222222 } /* Name.Variable */
-c-[k] { color: #990055 } /* Keyword */
+c-[k] { color: #d91e18 } /* Keyword */
 c-[l] { color: #000000 } /* Literal */
 c-[m] { color: #000000 } /* Literal.Number */
-c-[n] { color: #0077aa } /* Name */
-c-[o] { color: #999999 } /* Operator */
-c-[p] { color: #999999 } /* Punctuation */
-c-[s] { color: #a67f59 } /* Literal.String */
-c-[t] { color: #a67f59 } /* Literal.String.Single */
-c-[u] { color: #a67f59 } /* Literal.String.Double */
-c-[cp] { color: #708090 } /* Comment.Preproc */
-c-[c1] { color: #708090 } /* Comment.Single */
-c-[cs] { color: #708090 } /* Comment.Special */
-c-[kc] { color: #990055 } /* Keyword.Constant */
-c-[kn] { color: #990055 } /* Keyword.Namespace */
-c-[kp] { color: #990055 } /* Keyword.Pseudo */
-c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[n] { color: #007299 } /* Name */
+c-[o] { color: #008000 } /* Operator */
+c-[p] { color: #545454 } /* Punctuation */
+c-[s] { color: #aa5d00 } /* Literal.String */
+c-[t] { color: #aa5d00 } /* Literal.String.Single */
+c-[u] { color: #aa5d00 } /* Literal.String.Double */
+c-[cp] { color: #696969 } /* Comment.Preproc */
+c-[c1] { color: #696969 } /* Comment.Single */
+c-[cs] { color: #696969 } /* Comment.Special */
+c-[kc] { color: #d91e18 } /* Keyword.Constant */
+c-[kn] { color: #d91e18 } /* Keyword.Namespace */
+c-[kp] { color: #d91e18 } /* Keyword.Pseudo */
+c-[kr] { color: #d91e18 } /* Keyword.Reserved */
 c-[ld] { color: #000000 } /* Literal.Date */
-c-[nc] { color: #0077aa } /* Name.Class */
-c-[no] { color: #0077aa } /* Name.Constant */
-c-[nd] { color: #0077aa } /* Name.Decorator */
-c-[ni] { color: #0077aa } /* Name.Entity */
-c-[ne] { color: #0077aa } /* Name.Exception */
-c-[nf] { color: #0077aa } /* Name.Function */
-c-[nl] { color: #0077aa } /* Name.Label */
-c-[nn] { color: #0077aa } /* Name.Namespace */
-c-[py] { color: #0077aa } /* Name.Property */
-c-[ow] { color: #999999 } /* Operator.Word */
+c-[nc] { color: #007299 } /* Name.Class */
+c-[no] { color: #007299 } /* Name.Constant */
+c-[nd] { color: #007299 } /* Name.Decorator */
+c-[ni] { color: #007299 } /* Name.Entity */
+c-[ne] { color: #007299 } /* Name.Exception */
+c-[nf] { color: #007299 } /* Name.Function */
+c-[nl] { color: #007299 } /* Name.Label */
+c-[nn] { color: #007299 } /* Name.Namespace */
+c-[py] { color: #007299 } /* Name.Property */
+c-[ow] { color: #008000 } /* Operator.Word */
 c-[mb] { color: #000000 } /* Literal.Number.Bin */
 c-[mf] { color: #000000 } /* Literal.Number.Float */
 c-[mh] { color: #000000 } /* Literal.Number.Hex */
 c-[mi] { color: #000000 } /* Literal.Number.Integer */
 c-[mo] { color: #000000 } /* Literal.Number.Oct */
-c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
-c-[sc] { color: #a67f59 } /* Literal.String.Char */
-c-[sd] { color: #a67f59 } /* Literal.String.Doc */
-c-[se] { color: #a67f59 } /* Literal.String.Escape */
-c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
-c-[si] { color: #a67f59 } /* Literal.String.Interpol */
-c-[sx] { color: #a67f59 } /* Literal.String.Other */
-c-[sr] { color: #a67f59 } /* Literal.String.Regex */
-c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
-c-[vc] { color: #0077aa } /* Name.Variable.Class */
-c-[vg] { color: #0077aa } /* Name.Variable.Global */
-c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[sb] { color: #aa5d00 } /* Literal.String.Backtick */
+c-[sc] { color: #aa5d00 } /* Literal.String.Char */
+c-[sd] { color: #aa5d00 } /* Literal.String.Doc */
+c-[se] { color: #aa5d00 } /* Literal.String.Escape */
+c-[sh] { color: #aa5d00 } /* Literal.String.Heredoc */
+c-[si] { color: #aa5d00 } /* Literal.String.Interpol */
+c-[sx] { color: #aa5d00 } /* Literal.String.Other */
+c-[sr] { color: #aa5d00 } /* Literal.String.Regex */
+c-[ss] { color: #aa5d00 } /* Literal.String.Symbol */
+c-[vc] { color: #007299 } /* Name.Variable.Class */
+c-[vg] { color: #007299 } /* Name.Variable.Global */
+c-[vi] { color: #007299 } /* Name.Variable.Instance */
 c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 '''
 


### PR DESCRIPTION
Updated the colors as discussed in #25.

I mapped manually from Prism-style token names to those from Pygments, testing it out in WHATWG specs by pasting the generated styles in dev tools.